### PR TITLE
Additional updates to check_pkgs, + program breaks on prep_spatial.R

### DIFF
--- a/scripts/00_source/check_pkgs.R
+++ b/scripts/00_source/check_pkgs.R
@@ -19,7 +19,7 @@ if (length(new_pkgs) == 0) {
     
     cat("Following packages have not yet been installed:\n")
     cat(paste0(new_pkgs, "\n"))
-    cat(red("Would you like to install these packages and their dependencies? (Y/N): "))
+    cat("Would you like to install these packages and their dependencies? (Y/N): ")
     ans1 <- readline(" ")
 
     # for microclim a, installation via github (requires devtools, Rtools, and rnoaa dependency)

--- a/scripts/00_source/check_pkgs.R
+++ b/scripts/00_source/check_pkgs.R
@@ -17,16 +17,15 @@ if (length(new_pkgs) == 0) {
     # prompt user to confirm whether or not to install required packages
   if (length(new_pkgs)) {
     
-    cat(paste0("\033[0;31mFollowing packages have not yet been installed:\033[0m","\n")) # 41 = white text, red bg, 31 = red text
+    cat("\033[0;31mFollowing packages have not yet been installed:\033[0m\n") # 41 = white text, red bg, 31 = red text
     cat(paste0(new_pkgs, "\n"))
-    cat(paste0("\033[0;31mWould you like to install these packages and their dependencies? (Y/N): \033[0m","\n")) # 41 = white text, red bg, 31 = red text
-    # cat("Would you like to install these packages and their dependencies? (Y/N): ")
+    cat("\033[0;31mWould you like to install these packages and their dependencies? (Y/N): \033[0m\n")
     ans1 <- readline(" ")
 
     # for microclim a, installation via github (requires devtools, Rtools, and rnoaa dependency)
-    if (c("microclima", "zen4R") %in% new_pkgs) {
+    if (sum(c("microclima", "zen4R") %in% new_pkgs)>0) {
       if (!"devtools" %in% installed.packages()[,"Package"]) {
-        ans2 <- readline("Package `devtools` is required to install packages from GitHub Install devtools? (Y/N): ")
+        ans2 <- readline("Package `devtools` is required to install packages from GitHub.\nInstall devtools? (Y/N): ")
         
         if (!tolower(ans2) %in% c("y", "yes")) {
           warning("Packages have not been installed. Scripts are not guaranteed to run.\n")
@@ -64,13 +63,10 @@ if (length(new_pkgs) == 0) {
   } else cat("All required packages have been installed succesfully.\n")
   
   # Garbage collect
-  gc()
+  invisible(gc())
   
-  cat("We recommend restarting your R session (Session > Restart R).\n")
+  cat("We recommend restarting your R session (For RStudio users: Session > Restart R or CTRL+SHIFT+F10).\n")
   
   # Attempt to remove both objects, suppress warnings
-  suppressWarnings(rm(list = c("ans1", "ans2")))
+  suppressWarnings(rm(list = c("ans1", "ans2", "pkgs", "new_pkgs")))
 }
-
-# clean environment  
-rm(list = c("pkgs", "new_pkgs"))

--- a/scripts/00_source/check_pkgs.R
+++ b/scripts/00_source/check_pkgs.R
@@ -17,7 +17,7 @@ if (length(new_pkgs) == 0) {
     # prompt user to confirm whether or not to install required packages
   if (length(new_pkgs)) {
     
-    cat(red("Following packages have not yet been installed:\n"))
+    cat("Following packages have not yet been installed:\n")
     cat(paste0(new_pkgs, "\n"))
     cat(red("Would you like to install these packages and their dependencies? (Y/N): "))
     ans1 <- readline(" ")

--- a/scripts/00_source/check_pkgs.R
+++ b/scripts/00_source/check_pkgs.R
@@ -5,7 +5,7 @@ cat("Checking installed packages\n")
 # list all required packages for the scripts to run
 pkgs <- c("tidyverse", "elevatr", "rnoaa", "microclima", "terra", "landscapemetrics",
           "pwr", "sf", "factoextra", "FactoMineR", "ggplot2", "RColorBrewer", "viridis", 
-          "crayon", "geodata", "zen4R")
+          "crayon", "geodata", "zen4R") # crayon required?
 
 # find the packages that have not yet been installed on the device
 new_pkgs <- pkgs[!(pkgs %in% installed.packages()[,"Package"])]
@@ -65,7 +65,7 @@ if (length(new_pkgs) == 0) {
   # Garbage collect
   invisible(gc())
   
-  cat("We recommend restarting your R session (For RStudio users: Session > Restart R or CTRL+SHIFT+F10).\n")
+  cat("\033[0;31mWe recommend restarting your R session (For RStudio users: Session > Restart R or CTRL+SHIFT+F10).\033[0m\n")
   
   # Attempt to remove both objects, suppress warnings
   suppressWarnings(rm(list = c("ans1", "ans2", "pkgs", "new_pkgs")))

--- a/scripts/00_source/check_pkgs.R
+++ b/scripts/00_source/check_pkgs.R
@@ -17,9 +17,10 @@ if (length(new_pkgs) == 0) {
     # prompt user to confirm whether or not to install required packages
   if (length(new_pkgs)) {
     
-    cat("Following packages have not yet been installed:\n")
+    cat(paste0("\033[0;31mFollowing packages have not yet been installed:\033[0m","\n")) # 41 = white text, red bg, 31 = red text
     cat(paste0(new_pkgs, "\n"))
-    cat("Would you like to install these packages and their dependencies? (Y/N): ")
+    cat(paste0("\033[0;31mWould you like to install these packages and their dependencies? (Y/N): \033[0m","\n")) # 41 = white text, red bg, 31 = red text
+    # cat("Would you like to install these packages and their dependencies? (Y/N): ")
     ans1 <- readline(" ")
 
     # for microclim a, installation via github (requires devtools, Rtools, and rnoaa dependency)

--- a/scripts/00_source/check_pkgs.R
+++ b/scripts/00_source/check_pkgs.R
@@ -65,7 +65,7 @@ if (length(new_pkgs) == 0) {
   # Garbage collect
   invisible(gc())
   
-  cat("\033[0;31mWe recommend restarting your R session (For RStudio users: Session > Restart R or CTRL+SHIFT+F10).\033[0m\n")
+  cat(crayon::red("We recommend restarting your R session (For RStudio users: Session > Restart R or CTRL+SHIFT+F10).\n"))
   
   # Attempt to remove both objects, suppress warnings
   suppressWarnings(rm(list = c("ans1", "ans2", "pkgs", "new_pkgs")))

--- a/scripts/00_source/functions.R
+++ b/scripts/00_source/functions.R
@@ -23,7 +23,7 @@ save_raster <- function(rst, filepath, filepattern) {
     }
   } else {
     if (!file.exists(dirname(filepath))) {
-      cat(red("Directory `", filepath, "` does not yet exist\n Create directory? (Y/N)\n"))
+      cat(red("Directory `", filepath, "` does not yet exist.\n Create directory? (Y/N)\n"))
       ans2 <- readline(" ")
 
       if (tolower(ans2) %in% c("y", "yes")) {

--- a/scripts/00_source/functions.R
+++ b/scripts/00_source/functions.R
@@ -22,6 +22,18 @@ save_raster <- function(rst, filepath, filepattern) {
       cat("File not overwritten, continuing program.\n")
     }
   } else {
+    if (!file.exists(dirname(filepath))) {
+      cat(red("Directory `", filepath, "` does not yet exist\n Create directory? (Y/N)\n"))
+      ans2 <- readline(" ")
+
+      if (tolower(ans2) %in% c("y", "yes")) {
+        dir.create(dirname(filepath), recursive = TRUE)
+        cat(red("Creating directory: ", filepath))
+      } else if (tolower(ans2) %in% c("n", "no")) {
+        stop("Directory was not created, program ended.")
+      }
+      
+    }
     writeRaster(rst, paste0(filepath,
                                   filepattern, ".tif"))
   }

--- a/scripts/03_data_extraction/prep_spatial.R
+++ b/scripts/03_data_extraction/prep_spatial.R
@@ -16,7 +16,7 @@ for (i in seq_along(pkgs)) {
 
 
 # Confirm script should be run
-if (program_rerun) {
+if (program_rerun) { # running the code non-sequentially (e.g. running prep_spatial.R first) will break the program
   cat(red("program_rerun set to TRUE, so you should not need to re-run prep_spatial.R. Do you wish to continue? (Y/N): "))
   ans1 <- readline(" ")
   
@@ -25,11 +25,11 @@ if (program_rerun) {
   }
   
   if (tolower(ans1) %in% c("n", "no")) {
-    cat("Skipping prep_spatial.R. \n")
+    cat(red("Skipping prep_spatial.R. \n"))
     continue <- FALSE
   }
   if (tolower(ans1) %in% c("y", "yes")) {
-    cat("Continuing program.\n")
+    cat(red("Continuing program.\n"))
     continue <- TRUE
   }
 } else {
@@ -38,7 +38,7 @@ if (program_rerun) {
 
 if (continue) {
   
-  cat("Prepping spatial data...\n")
+  cat(red("Prepping spatial data...\n"))
   
   ## Workspace prep -----------
   
@@ -134,17 +134,20 @@ if (continue) {
     if (!file.exists("data/spatial_drivers/microclimate/soil_bio/SBIO1_0_5cm_Annual_Mean_Temperature.tif")) {
       cat(red("Global soil temperature maps must be downloaded from Zenodo in order to include. Continue? (Y/N): "))
       ans1 <- readline(" ")
-      
       if (!tolower(ans1) %in% c("n", "no", "y", "yes")) {
         stop("Inappropriate input. Must be one of: yes, YES, Y, y, no, NO, N, n.\n")
       }
       
       if (tolower(ans1) %in% c("n", "no")) {
-        cat("NOT downloading global BIO1 soil temperature, and so removing soiltemp from `chosen_layers`\n")
+        cat(red("NOT downloading global BIO1 soil temperature, and so removing soiltemp from `chosen_layers`\n"))
         chosen_layers <- chosen_layers[chosen_layers != "soiltemp"]
       }
       if (tolower(ans1) %in% c("y", "yes")) {
-        cat("Downloading global BIO1 soil temperature.... \n")
+        cat(red("Downloading global BIO1 soil temperature.... \n"))
+        if (!file.exists("data/spatial_drivers/microclimate/soil_bio")) {
+          cat(red("Creating folder 'data/spatial_drivers/microclimate/soil_bio'\n"))
+          dir.create("data/spatial_drivers/microclimate/soil_bio", recursive = TRUE)
+        }
         zen4R::download_zenodo(doi = "10.5281/zenodo.7134169", 
                                path = "data/spatial_drivers/microclimate/soil_bio/", 
                                files = "SBIO1_0_5cm_Annual_Mean_Temperature.tif",
@@ -161,10 +164,10 @@ if (continue) {
   if (any(complete.cases(custom_layers_test))) {
     custom_layers_r <- lapply(custom_layers_test, function(l) {
       if (file.exists(l)) {
-        cat("Reading in custom layers", l, "\n")
+        cat(red("Reading in custom layers", l, "\n"))
         return(rast(l))
       } else {
-        cat("No file found for filepath", l, "so ignoring.\n")
+        cat(red("No file found for filepath", l, "so ignoring.\n"))
         return(NA)
       }
     })
@@ -243,7 +246,7 @@ if (continue) {
   finest_rez_layer <- chosen_layers_list[which.min(unlist(layer_resolutions))][[1]]
   
   # Resample all layers
-  cat("Standardizing spatial information across chosen layers...\n")
+  cat(red("Standardizing spatial information across chosen layers...\n"))
   chosen_layers_list <- lapply(chosen_layers_list, function(x) {
     # Resample all layers to the layer with the finest resolution. But, use 
     # method = "near" so we aren't interpolating categorical data or making 

--- a/scripts/03_data_extraction/prep_spatial.R
+++ b/scripts/03_data_extraction/prep_spatial.R
@@ -187,7 +187,7 @@ if (continue) {
     # Save landcover file. But first, check if already exists and ask user if they
     # want to overwrite
     save_raster(landcover, 
-                "data/spatial_drivers/landcover/deriative/landcover_", 
+                "data/spatial_drivers/landcover/derivative/landcover_", 
                 filepattern)
   }
   
@@ -200,7 +200,7 @@ if (continue) {
     # Save landcover file. But first, check if already exists and ask user if they
     # want to overwrite
     save_raster(macroclimate, 
-                "data/spatial_drivers/macroclimate/deriative/macroclimate_", 
+                "data/spatial_drivers/macroclimate/derivative/macroclimate_", 
                 filepattern)
   }
   
@@ -213,7 +213,7 @@ if (continue) {
     # Save landcover file. But first, check if already exists and ask user if they
     # want to overwrite
     save_raster(soiltemp, 
-                "data/spatial_drivers/soiltemp/deriative/soiltemp_", 
+                "data/spatial_drivers/soiltemp/derivative/soiltemp_", 
                 filepattern)
   }
   

--- a/scripts/04_site_selection/site_selection.R
+++ b/scripts/04_site_selection/site_selection.R
@@ -408,7 +408,7 @@ if (!program_rerun) {
   Steps_Dim.2<-(max(terrain_df$Dim.2)-min(terrain_df$Dim.2))/Groups
   Steps_Dim.3<-(max(terrain_df$Dim.3)-min(terrain_df$Dim.3))/Groups
   
-  cat("\n\nBEGINNING SITE SELECTION....\n\n")
+  cat(red("\n\nBEGINNING SITE SELECTION....\n\n"))
   
   # Sleep for 1.5 seconds so user can see messages
   Sys.sleep(1.5)
@@ -498,7 +498,7 @@ selected_sites <- check_max_dist(selected_sites, max_distance, attempts = 10, re
 # Check that all sites are above minimum distance
 selected_sites <- check_min_dist(selected_sites, min_distance, attempts = 10, recur = 0)
 
-cat("COMPLETED SITE SELECTION.\n")
+cat(red("COMPLETED SITE SELECTION.\n"))
 
 ## ....Checks on sites -------------
 
@@ -622,6 +622,18 @@ if (file.exists(paste0("data/chosen_sites/selected_sites_",
   ans1 <- readline(" ")
   
   if (tolower(ans1) %in% c("y", "yes")) {
+    
+    if (!file.exists(dirname("data/landscape_data/"))) {
+      cat(red("Directory `data/landscape_data` does not exist.\n Create directory? (Y/N)\n"))
+      ans2 <- readline(" ")
+      
+      if (tolower(ans2) %in% c("y", "yes")) {
+        cat(red("Creating directory: `data/landscape_data`"))
+        dir.create("data/landscape_data")
+      } else {
+        stop("Directory was not created, program ended.")
+      }
+    }
 
     write_csv(terrain_df, paste0("data/landscape_data/landscape_bins_", filepattern,
                                  "_", n_sites, ".csv"))
@@ -630,7 +642,7 @@ if (file.exists(paste0("data/chosen_sites/selected_sites_",
     cat("\n\nSelected sites are saved to a CSV file:\n", paste0("data/chosen_sites/selected_sites_", filepattern, "_", n_sites, ".csv"))
   }
   if (tolower(ans1) %in% c("n", "no")) {
-    cat("File not overwritten, but selected sites still availabile in object `selected_sites`.\n")
+    cat("File not overwritten, but selected sites still available in object `selected_sites`.\n")
   }
 } else {
   write_csv(terrain_df, paste0("data/landscape_data/landscape_bins_", 

--- a/scripts/main.R
+++ b/scripts/main.R
@@ -8,8 +8,8 @@
 ## If running the program for the first time: run these lines of code
 ## Please execute each of these lines of code one at a time, as some scripts
 ## require user input in the console
-source("scripts/00_source/functions.R")
 source("scripts/00_source/check_pkgs.R")
+source("scripts/00_source/functions.R")
 source("scripts/01_parameters/set_parameters.R")
 source("scripts/01_parameters/check_parameters.R")
 source("scripts/02_power_analysis/power_analysis.R")


### PR DESCRIPTION
Mostly changes to check_pkgs.R, given that it no longer ran out of the box. E.g., crayon::red() was called, though crayon() had not yet been loaded (and may not yet have been installed, either). Used the code underlying crayon (ANSI) to draw red text in console, until the point where crayon has been installed. Also thought of something for the package -> we may want to add some lines of code to account for non-interactive R environments where readline could potentially cause the program to break.

In any case, trying to run through the code again got stuck on L87 in prep_spatial.R:
landcover_global <- terra::rast("data/spatial_drivers/landcover/original/esa_cci/ESACCI-LC-L4-LCCS-Map-300m-P1Y-2015-v2.0.7.tif")

More specifically, said .tif file does not exist, and afaik is not generated elsewhere. Is this file supposed to be present as part of the code supplement? They way it's written, I don't think it's a placeholder for users to input their own data layers.

UPDATE:
Seems like there were some typos in hardcoded filepaths (see commits), as well as the problem of parts missing in the folder structure that was part of pulling your R project repo - updated the save_raster function to alleviate this, though this may only be a temporary fix (i.e., if a complete folder structure is provided beforehand, this may no longer be necessary).

Currently, I've managed to run the supplement out of the box up until and including prep_spatial.R without too the program breaking. In site_selection.R, the code is currently crashing for me when answering "y" to following prompt:
File  data/chosen_sites/selected_sites_Flanders_150.csv  already exists. Overwrite? (Y/N): 
Code does not appear to break when answering "n". I'll get back to it asap, it's getting late over here!

Cheers

Stijn